### PR TITLE
Sparse mat

### DIFF
--- a/R/countsplit.R
+++ b/R/countsplit.R
@@ -1,25 +1,32 @@
-#' Takes one matrix of counts and returns a list containing two matrices of counts: a training set and a test set. 
-#' 
-#' Be sure to see the countsplitting tutorial vignette for details of how to use this correctly with existing 
-#' single cell RNA-seq pipelines. 
-#' 
+#' Takes one matrix of counts and returns a list containing two matrices of counts: a training set and a test set.
+#'
+#' Be sure to see the countsplitting tutorial vignette for details of how to use this correctly with existing
+#' single cell RNA-seq pipelines.
+#'
 #' @export
 #' @importFrom stats rbinom
-#' 
+#'
 #' @param X A cell-by-gene matrix of integer counts
 #' @param epsilon The thinning parameter for count splitting. Must be between 0 and 1.
 countsplit <- function(X, epsilon=0.5) {
   if (epsilon <= 0 | epsilon >= 1) {
     stop('Parameter epsilon must be in (0,1)')
   }
-  
-  Xtrain <-apply(X,2,function(u) rbinom(n=length(u), size=u, prob=epsilon))
-  rownames(Xtrain) <- rownames(X)
-  colnames(Xtrain) <- colnames(X)
-  Xtest <- X-Xtrain
-  rownames(Xtest) <- rownames(X)
-  colnames(Xtest) <- colnames(X)
-  
+
+  ## sparse formulation which samples only non-zero entries
+  ## and replace sampled value inplace
+  if(class(X) == 'dgCMatrix'){
+    Xtrain <- X
+    Xtrain@x <- rbinom(n=length(X@x), size=X@x, prob=epsilon)
+    Xtest <- X-Xtrain
+  } else {
+    ## dense formulation
+    Xtrain <-apply(X,2,function(u) rbinom(n=length(u), size=u, prob=epsilon))
+    rownames(Xtrain) <- rownames(X)
+    colnames(Xtrain) <- colnames(X)
+    Xtest <- X-Xtrain
+    rownames(Xtest) <- rownames(X)
+    colnames(Xtest) <- colnames(X)
+  }
   return(list(train=Xtrain, test=Xtest))
 }
-

--- a/R/test_sparse_formulation.R
+++ b/R/test_sparse_formulation.R
@@ -1,0 +1,29 @@
+library(countsplit)
+
+## from https://anna-neufeld.github.io/countsplit/articles/seurat_tutorial.html
+data(pbmc.counts, package="countsplit")
+rownames(pbmc.counts) <- sapply(rownames(pbmc.counts), function(u) stringr::str_replace_all(u, "_","-"))
+
+#########################################
+## 1) run countsplit w/ sparse formulation
+startTime <- Sys.time()
+set.seed(1)
+split <- countsplit(pbmc.counts, epsilon=0.5)
+Xtrain <- split$train
+Xtest <- split$test
+
+endTime <- Sys.time()
+print(endTime - startTime) #Time difference of 0.3524549 secs
+
+
+#########################################
+## 2) run countsplit w/ dense formulation
+startTime2 <- Sys.time()
+pbmc.counts.dense = as.matrix(pbmc.counts)
+set.seed(1)
+split2 <- countsplit(pbmc.counts.dense, epsilon=0.5)
+Xtrain.dense <- split2$train
+Xtest.dense <- split2$test
+
+endTime2 <- Sys.time()
+print(endTime2 - startTime2) # Time difference of 6.527817 secs


### PR DESCRIPTION
Implements count split for dgCMatrix sparse matrix. Does not densify matrix. Also reduce sampling only to non-zero counts. This implementation would save RAM and increase speed. 